### PR TITLE
Fixed install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Install all the components:
 
 ```javascript
 import Vue from 'vue'
-import VueInstant from 'vue-instant'
 import 'vue-instant/dist/vue-instant.css'
+import VueInstant from 'vue-instant/dist/vue-instant.common'
 Vue.use(VueInstant)
 ```
 **⚠️ You need to configure your bundler to compile `.vue` files.** More info [in the official documentation](https://vuejs.org/v2/guide/single-file-components.html).


### PR DESCRIPTION
Hi,

adding your component to my vue project on webpack worked for me only with these modified import statements. May it be that the Readme is outdated on that part?