### PR TITLE
Fix the example

### DIFF
--- a/examples/webpack-example/src/App.vue
+++ b/examples/webpack-example/src/App.vue
@@ -60,9 +60,6 @@ export default {
               that.suggestions.push(a)
           })
       })
-    },
-    components: {
-      'vue-instant': VueInstant
     }
   }
 }

--- a/examples/webpack-example/src/App.vue
+++ b/examples/webpack-example/src/App.vue
@@ -60,11 +60,11 @@ export default {
               that.suggestions.push(a)
           })
       })
-  },
-  components: {
-    'vue-instant': VueInstant
+    },
+    components: {
+      'vue-instant': VueInstant
+    }
   }
-}
 }
 </script>
 


### PR DESCRIPTION
The property `components` was useless because this property was in the `methods` instead of the root. This was caused by a indentation problem. The documentation should be updated accordinaly. The closed issue #7 is related. 