### PR TITLE
fix 2 way binding with v-model prop

### DIFF
--- a/src/components/VueInstant.vue
+++ b/src/components/VueInstant.vue
@@ -90,7 +90,6 @@
         suggestionsIsVisible: true,
         highlightedIndex: 0,
         highlightedIndexMax: 7,
-        textVal: this.value,
         similiarData: [],
         placeholderVal: this.placeholder,
         types: [{
@@ -215,6 +214,15 @@
       getSVGClear () {
         var type = this.getType()
         return type.svgClear
+      },
+
+      textVal: {
+        get () {
+          return this.value
+        },
+        set (v) {
+          this.$emit('input', v)
+        }
       }
     },
     methods: {

--- a/src/components/VueInstant.vue
+++ b/src/components/VueInstant.vue
@@ -470,7 +470,7 @@
         this.emitSelected()
       },
       emitChange () {
-        this.$emit('input', this.textVal)
+        // this.$emit('input', this.textVal)
       },
       emitClickInput (event) {
         this.$emit('click-input', event)


### PR DESCRIPTION
Instead of puting `textVal` as a independant data, put it as a computed property that is updated (and update) the `input` (which is the value binded in the v-model) 
The pull-request closes #23. 