### PR TITLE
added tabindex=-1 on placeholder and buttons to fix ux bugs

### DIFF
--- a/src/components/VueInstant.vue
+++ b/src/components/VueInstant.vue
@@ -3,14 +3,14 @@
     <div class="main">
       <form novalidate="novalidate" onsubmit="return false;" :class="getFormClass">
         <div role="search" :class="getClassWrapper">
-          <input type="search" name="search" :placeholder="getPlaceholder" autocomplete="off" required="required" :class="getClassInputPlaceholder">
+          <input type="search" name="search" :placeholder="getPlaceholder" autocomplete="off" required="required" :class="getClassInputPlaceholder" tabindex="-1">
           <input :disabled="disabled" @click="emitClickInput" @keyup='changeText' v-model='textVal' type="search" :name="name" placeholder="" autocomplete="off" required="required" :class="getClassInput" :autofocus="autofocus">
-          <button @click="emitClickButton" type="submit" :class="getClassSubmit">
+          <button @click="emitClickButton" type="submit" :class="getClassSubmit" tabindex="-1">
             <svg role="img" aria-label="Search">
               <use xmlns:xlink="http://www.w3.org/1999/xlink" :xlink:href="getSVGSearch"></use>
             </svg>
           </button>
-          <button @click="reset" type="reset" :class="getClassReset">
+          <button @click="reset" type="reset" :class="getClassReset" tabindex="-1">
             <svg role="img" aria-label="Reset">
               <use xmlns:xlink="http://www.w3.org/1999/xlink" :xlink:href="getSVGClear"></use>
             </svg>


### PR DESCRIPTION
I noticed a bug in user experience when pressing tab,
when a user press tab and the focus goes on the placeholder input
the user will be able to input characters on the placeholder input overlapping with the 
main input.

Fixed it by adding tabindex="-1"

added it also on buttons so when the user pressed tab you'll be able to go on other inputs 
that is relevant the main form, this is helpful in a booking forms.