### PR TITLE
Added prop 'suggestOnAllWords' 

### DIFF
--- a/src/components/VueInstant.vue
+++ b/src/components/VueInstant.vue
@@ -80,6 +80,10 @@
       'showAutocomplete': {
         type: Boolean,
         default: true
+      },
+      'suggestOnAllWords': {
+        type: Boolean,
+	default: false
       }
     },
     data () {
@@ -384,10 +388,33 @@
             this.placeholderVal === '' && this.highlightedIndex !== 0
       },
       isSimilar (o) {
-        if (o) {
-          return o[this.suggestionAttribute]
-                  .toLowerCase()
-                  .startsWith(this.textVal.toLowerCase())
+          if (o) {
+	   if ( this.suggestOnAllWords ) {
+	      var isMatch = false;
+	      var words = o[this.suggestionAttribute].split(" ");
+	      var textValWords = this.textVal.split(" ");
+	      if ( words.length > 0) {
+		  words.forEach(function(word)  {
+		      if ( textValWords.length > 0) {
+			  textValWords.forEach(function(textValWord) {
+			      if (word.toLowerCase().startsWith(textValWord.toLowerCase())) {
+				  isMatch = true;
+			      }
+			  });
+		      }
+		      else if (word.toLowerCase().startsWith(this.textVal.toLowerCase())) {
+			  isMatch = true;
+		      }
+		  });
+		  return isMatch;
+	      } 
+	   }
+
+           return o[this.suggestionAttribute]
+        	  .toLowerCase()
+		  .startsWith(this.textVal.toLowerCase())		  
+
+
         }
       },
       isSameType (o) {


### PR DESCRIPTION
Added Boolean prop 'suggestOnAllWords' which if set to true, will enable suggestions on more than one input word in search hit(s).

To demonstrate, using the same API as in your examples, searching "Beautiful mind" will not give much:

![suggestonallwords-false](https://user-images.githubusercontent.com/74072/31387833-22de41fa-adcc-11e7-836a-1638755c0d7b.png)

Setting 'suggestOnAllWords' to true, the result will look like this:

![suggestonallwords-true](https://user-images.githubusercontent.com/74072/31387906-702e646c-adcc-11e7-94ca-84bf3e4f72df.png)

This feature is also useful when you have search results that have many similar values.

I read your contribution guidelines a tad too late unfortunately - let me know if this is of any interest and I can provide the further work.



